### PR TITLE
VP-1508: Fix sandwich menu button in header

### DIFF
--- a/client-app/src/pages/init/main.ts
+++ b/client-app/src/pages/init/main.ts
@@ -1,5 +1,6 @@
 import Vue from "vue";
 import i18n from "@i18n";
+import "bootstrap/js/src";
 import "styles/default.scss";
 import "vue-loading-overlay/dist/vue-loading.css";
 import InitializationService from '@common/services/initialization.service';


### PR DESCRIPTION
We need to load bootstrap.js only single time on page, in our case - in ini-app.
If we import it in initialization service, then it may happen 2 times:
* in init-app
* in account