### PR TITLE
Fix browser compatibility

### DIFF
--- a/client-app/.browserslistrc
+++ b/client-app/.browserslistrc
@@ -1,2 +1,3 @@
 > 1%
 last 2 versions
+last 2 edge versions

--- a/client-app/.eslintrc.js
+++ b/client-app/.eslintrc.js
@@ -59,7 +59,9 @@ module.exports = {
         "order": "asc"
       }
     }],
-    "no-prototype-builtins": "off"
+    "no-prototype-builtins": "off",
+    "comma-dangle": ["error", "never"],
+    "quote-props": ["error", "as-needed", { "keywords": true, "unnecessary": true }]
   },
   parserOptions: {
     parser: "@typescript-eslint/parser"

--- a/client-app/package-lock.json
+++ b/client-app/package-lock.json
@@ -6948,7 +6948,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7365,7 +7366,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7421,6 +7423,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7464,12 +7467,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/client-app/src/core/services/initialization.service.ts
+++ b/client-app/src/core/services/initialization.service.ts
@@ -1,13 +1,13 @@
-import Vue from 'vue';
+import Vue from "vue";
 import VueAxios from "vue-axios";
-import Loading from 'vue-loading-overlay';
+import Loading from "vue-loading-overlay";
 import "vue-moment";
 import VueRx from "vue-rx";
-import Vuelidate from 'vuelidate';
-import { library, dom } from '@fortawesome/fontawesome-svg-core';
-import { faHeartBroken, faLock, faMeteor, faThLarge, faList, faShoppingCart, faCamera, faCalculator, faChartBar, faFileAlt, faSearch } from '@fortawesome/free-solid-svg-icons';
+import Vuelidate from "vuelidate";
+import { library, dom } from "@fortawesome/fontawesome-svg-core";
+import { faHeartBroken, faLock, faMeteor, faThLarge, faList, faShoppingCart, faCamera, faCalculator, faChartBar, faFileAlt, faSearch } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon, FontAwesomeLayers } from "@fortawesome/vue-fontawesome";
-import { ButtonPlugin, CollapsePlugin, PaginationPlugin, TablePlugin, ToastPlugin, ModalPlugin, CardPlugin, DropdownPlugin, FormCheckboxPlugin, FormGroupPlugin, FormDatepickerPlugin, FormInputPlugin, FormPlugin, FormSelectPlugin, InputGroupPlugin, TooltipPlugin, SidebarPlugin, OverlayPlugin } from 'bootstrap-vue';
+import { ButtonPlugin, CollapsePlugin, PaginationPlugin, TablePlugin, ToastPlugin, ModalPlugin, CardPlugin, DropdownPlugin, FormCheckboxPlugin, FormGroupPlugin, FormDatepickerPlugin, FormInputPlugin, FormPlugin, FormSelectPlugin, InputGroupPlugin, TooltipPlugin, SidebarPlugin, OverlayPlugin } from "bootstrap-vue";
 import axios from "core/services/axios-instance";
 
 export default class InitializationService {

--- a/client-app/src/core/utilities/comment-node.ts
+++ b/client-app/src/core/utilities/comment-node.ts
@@ -8,7 +8,7 @@ export function commentNode(el: any, vnode: any) {
   const comment = document.createComment(' ')
 
   Object.defineProperty(comment, 'setAttribute', {
-    value: () => undefined,
+    value: () => undefined
   })
 
   vnode.text = ' '

--- a/client-app/src/libs/invoice/store/invoices-list/index.ts
+++ b/client-app/src/libs/invoice/store/invoices-list/index.ts
@@ -16,7 +16,7 @@ export const initialState: InvoicesListState = {
   searchCriteria: {
     pageNumber: startPageNumber,
     pageSize: defaultPageSize,
-    statuses: [],
+    statuses: []
   },
   invoices: {
     totalCount: 0,

--- a/client-app/src/libs/invoice/store/invoices-list/mutations.ts
+++ b/client-app/src/libs/invoice/store/invoices-list/mutations.ts
@@ -16,5 +16,5 @@ export const mutations: MutationTree<InvoicesListState> = {
     state.invoices.results = payload.results  || [];
     state.invoices.totalCount = payload.totalCount || 0;
     setAsync(state);
-  },
+  }
 };

--- a/client-app/src/libs/payment/store/payments-list/index.ts
+++ b/client-app/src/libs/payment/store/payments-list/index.ts
@@ -16,7 +16,7 @@ export const initialState: PaymentsListState = {
   searchCriteria: {
     pageNumber: startPageNumber,
     pageSize: defaultPageSize,
-    statuses: [],
+    statuses: []
   },
   payments: {
     totalCount: 0,

--- a/client-app/src/libs/payment/store/payments-list/mutations.ts
+++ b/client-app/src/libs/payment/store/payments-list/mutations.ts
@@ -16,5 +16,5 @@ export const mutations: MutationTree<PaymentsListState> = {
     state.payments.results = payload.results  || [];
     state.payments.totalCount = payload.totalCount || 0;
     setAsync(state);
-  },
+  }
 };

--- a/client-app/src/pages/account/router/index.ts
+++ b/client-app/src/pages/account/router/index.ts
@@ -49,7 +49,7 @@ const routes = [
         beforeEnter: (to: any, from: any, next: any) => {
           const permitted = isPermitted(FeatureNames.OrderBrowsing, Permissions.CanViewOrders)
           accessHandler(permitted, next);
-        },
+        }
       },
       {
         path: '/invoices',
@@ -109,7 +109,7 @@ const routes = [
         meta: {
           title: i18n.t('account.menu_titles.home')
         }
-      },
+      }
     ]
   }
 ];

--- a/client-app/src/pages/account/views/account-drafts/account-drafts.ts
+++ b/client-app/src/pages/account/views/account-drafts/account-drafts.ts
@@ -74,7 +74,7 @@ export default class AccountDrafts extends Vue {
   pageChanged(page: number) {
     this.setSearchCriteria({
       ...this.searchCriteria,
-      pageNumber: page,
+      pageNumber: page
     });
   }
 
@@ -82,7 +82,7 @@ export default class AccountDrafts extends Vue {
     this.setSearchCriteria({
       ...this.searchCriteria,
       pageNumber: 1,
-      pageSize: pageSize,
+      pageSize: pageSize
     });
   }
 

--- a/client-app/src/pages/init/store/getters.ts
+++ b/client-app/src/pages/init/store/getters.ts
@@ -11,5 +11,5 @@ export const getters: GetterTree<State, State> = {
       ...error,
       timestamp$: interval(1000).pipe(map(() => error.timestamp))
     }));
-  },
+  }
 };

--- a/client-app/src/store/index.ts
+++ b/client-app/src/store/index.ts
@@ -9,7 +9,7 @@ Vue.use(Vuex);
 
 const store: StoreOptions<RootState> = {
   state: {},
-  strict: debug,
+  strict: debug
 };
 
 export default new Store<RootState>(store);

--- a/client-app/vue.config.js
+++ b/client-app/vue.config.js
@@ -9,6 +9,24 @@ module.exports = {
   outputDir: "../assets/static/bundle/dist",
   filenameHashing: false,
   runtimeCompiler: true,
+  transpileDependencies: [    
+    "@fortawesome/fontawesome-svg-core",
+    "@fortawesome/free-regular-svg-icons",
+    "@fortawesome/free-solid-svg-icons",
+    "@fortawesome/vue-fontawesome",
+    "axios",
+    "bootstrap-vue",
+    "rxjs",
+    "vue-axios",
+    "vue-i18n",
+    "vue-loading-overlay",
+    "vue-moment",
+    "vue-router",
+    "vue-rx",
+    "vuelidate",
+    "vuex",
+    "vuex-class"
+  ],
   devServer: {
     proxy: "http://localhost:2083"
   },


### PR DESCRIPTION
Description of changes:
1. Added Edge to list of supported browsers explicitly, because it may not meet default criterias, but we support it. Do the same for IE if we will support it.
1. Added `eslint` auto-fixable rules to avoid trailing commas and unquoted reserved words in object. They may cause problems in Edge (and IE, of course)
1. Added `transpileDependencies` section to `vue.config`. It should include _all_ dependencies with 4 exceptions:
    1. `vue` itself
    1. If dependency is not used in our `vue` apps (`jquery`, `popper.js` - `bootstrap.js` dependencies, can be used only in liquid)
    1. If we don't use js/ts from dependency in vue (`bootstrap` - we use only scss)
    1. if dependency will be compiled to javascript code (all `@types/`; `vue-class-component`, `vue-property-decorator` - they are typescript decorators which produce correct javascript code itself)