### PR TITLE
VP-2604: Implement vue directive to allow entering only number chars to the input element

### DIFF
--- a/client-app/src/core/directives/only-number.ts
+++ b/client-app/src/core/directives/only-number.ts
@@ -1,0 +1,30 @@
+import Vue from "vue";
+
+Vue.directive('only-number', {
+
+  bind: function (el) {
+
+    el.addEventListener("keydown",(event) => {
+      const e = event as KeyboardEvent;
+
+      if ([46, 8, 9, 27, 13].indexOf(e.keyCode) !== -1 ||
+          // Allow: Ctrl+A
+          (e.keyCode === 65 && (e.ctrlKey || e.metaKey)) ||
+          // Allow: Ctrl+C
+          (e.keyCode === 67 && (e.ctrlKey || e.metaKey)) ||
+          // Allow: Ctrl+V
+          (e.keyCode === 86 && (e.ctrlKey || e.metaKey)) ||
+          // Allow: Ctrl+X
+          (e.keyCode === 88 && (e.ctrlKey || e.metaKey)) ||
+          // Allow: home, end, left, right
+          (e.keyCode >= 35 && e.keyCode <= 39)) {
+        // let it happen, don't do anything
+        return;
+      }
+      // Ensure that it is a number and stop the keypress
+      if ((e.shiftKey || (e.keyCode < 48 || e.keyCode > 57)) && (e.keyCode < 96 || e.keyCode > 105)) {
+        e.preventDefault();
+      }
+    } );
+  }
+})

--- a/client-app/src/core/filters/img-url.ts
+++ b/client-app/src/core/filters/img-url.ts
@@ -2,10 +2,10 @@ import Vue from "vue";
 import { appendToFilename } from "@core/utilities/utilities";
 
 
-export function appendSuffixToImgUrl(value: string, suffix: string) {
+Vue.filter('imgUrl', (value: string, suffix: string) => {
   if (!value) return '';
   if (!suffix) return value;
   const result = appendToFilename(value, `_${suffix}`);
   return result;
-}
+});
 

--- a/client-app/src/core/services/initialization.service.ts
+++ b/client-app/src/core/services/initialization.service.ts
@@ -9,7 +9,8 @@ import { faHeartBroken, faLock, faMeteor, faThLarge, faList, faShoppingCart, faC
 import { FontAwesomeIcon, FontAwesomeLayers } from "@fortawesome/vue-fontawesome";
 import { ButtonPlugin, CollapsePlugin, PaginationPlugin, TablePlugin, ToastPlugin, ModalPlugin, CardPlugin, DropdownPlugin, FormCheckboxPlugin, FormGroupPlugin, FormDatepickerPlugin, FormInputPlugin, FormPlugin, FormSelectPlugin, InputGroupPlugin, TooltipPlugin, SidebarPlugin, OverlayPlugin } from "bootstrap-vue";
 import axios from "core/services/axios-instance";
-import { appendSuffixToImgUrl } from "@core/filters/imgUrl";
+import "@core/filters/img-url";
+import "@core/directives/only-number";
 
 export default class InitializationService {
   static initializeCommon() {
@@ -27,8 +28,6 @@ export default class InitializationService {
     //plugins
     Vue.use(VueRx);
     Vue.use(VueAxios, axios);
-
-    Vue.filter('imgUrl', appendSuffixToImgUrl);
 
     // workaround because of unstable build caused by broken .d.ts
     // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/client-app/src/libs/shopping-cart/components/change-item-quantity/change-item-quantity.ts
+++ b/client-app/src/libs/shopping-cart/components/change-item-quantity/change-item-quantity.ts
@@ -49,30 +49,6 @@ export default class ChangeItemQuantity extends Vue {
 
   }
 
-  keydown(event: any) {
-    const e = event as KeyboardEvent;
-
-    if ([46, 8, 9, 27, 13].indexOf(e.keyCode) !== -1 ||
-        // Allow: Ctrl+A
-        (e.keyCode === 65 && (e.ctrlKey || e.metaKey)) ||
-        // Allow: Ctrl+C
-        (e.keyCode === 67 && (e.ctrlKey || e.metaKey)) ||
-        // Allow: Ctrl+V
-        (e.keyCode === 86 && (e.ctrlKey || e.metaKey)) ||
-        // Allow: Ctrl+X
-        (e.keyCode === 88 && (e.ctrlKey || e.metaKey)) ||
-        // Allow: home, end, left, right
-        (e.keyCode >= 35 && e.keyCode <= 39)) {
-      // let it happen, don't do anything
-      return;
-    }
-    // Ensure that it is a number and stop the keypress
-    if ((e.shiftKey || (e.keyCode < 48 || e.keyCode > 57)) && (e.keyCode < 96 || e.keyCode > 105)) {
-      e.preventDefault();
-    }
-  }
-
-
   onQuantityChanged(value: number) {
     this.$emit("quantity-changed", value);
   }

--- a/client-app/src/libs/shopping-cart/components/change-item-quantity/index.vue
+++ b/client-app/src/libs/shopping-cart/components/change-item-quantity/index.vue
@@ -4,10 +4,10 @@
       <font-awesome-icon :icon="minusIcon" size="lg"></font-awesome-icon>
     </button>
     <div>
-      <input type="text"
+      <input v-only-number
+             type="text"
              class="form-control form-control-sm text-center"
              :value="model"
-             @keydown="keydown($event)"
              @blur="textChanged($event.target.value)"
              @keyup.enter="textChanged($event.target.value)">
     </div>


### PR DESCRIPTION
Example of usage

<input v-only-number
type="text"
class="form-control text-center"
:value="model"
>